### PR TITLE
Fix compile time error when try to initialize the ls_selectColumns

### DIFF
--- a/include/line_split.hpp
+++ b/include/line_split.hpp
@@ -9,7 +9,7 @@
  */
 #ifndef __LINE_SPLIT_HPP
 #define __LINE_SPLIT_HPP
-
+#define _CRT_SECURE_NO_WARNINGS
 #include <iostream>
 #include <sstream>
 #include <fstream>
@@ -70,7 +70,7 @@ public:
     char   *lpc_selectColumns;
     uintidx luintidx_limInf;
     uintidx luintidx_limSup;
-    char   ls_selectColumns[ aistr_selectColumns.length() + 2];
+    char*  ls_selectColumns = new char[aistr_selectColumns.length() + 2];  // to fix error at compile time
   
     using namespace std;
     istringstream   liss_stringstream;
@@ -103,6 +103,7 @@ public:
 	lpc_readItem = strtok(NULL, ",");
       }	
     } /*IF !NULL*/
+    delete[] ls_selectColumns;  // to liberate memory
   }
 
   uintidx split(std::string& str) 


### PR DESCRIPTION
When trying to use the library, the compiler throw an error because of the initialization of the array. So I fixed that error creating the array on the heap memory to allocated at run time and after the use, deleted to free space.